### PR TITLE
Add Codecov token to CI workflow

### DIFF
--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -71,7 +71,8 @@ jobs:
         if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.11'
         uses: codecov/codecov-action@v4
         with:
-          file: ./coverage.xml
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage.xml
           fail_ci_if_error: false
 
   # ============================================================================


### PR DESCRIPTION
## Summary
- Add `token` parameter to codecov-action@v4 for authenticated uploads
- Fix parameter name from `file` to `files` per v4 API spec

This fixes the "codecov=unknown" badge in the README by enabling proper coverage report uploads.

## Test plan
- [ ] CI passes on this branch
- [ ] Codecov receives coverage upload (check codecov.io dashboard)
- [ ] Badge updates from "unknown" to actual percentage after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)