### PR TITLE
Fix dependabot and codecov configuration errors

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=https://json.schemastore.org/codecov.json
+
 # Codecov Configuration
 # https://docs.codecov.com/docs/codecovyml-reference
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,13 +1,15 @@
+# yaml-language-server: $schema=https://json.schemastore.org/dependabot-2.0.json
+
 # To get started with Dependabot version updates, you'll need to specify which
 # package ecosystems to update and where the package manifests are located.
 # Please see the documentation for all configuration options:
 # https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
 
-version: 3
+version: 2
 updates:
   # 1. Python Backend Dependencies
   - package-ecosystem: "pip"
-    directory: "/weather-app" # Location of requirements.txt
+    directory: "/" # Location of requirements.txt
     schedule:
       interval: "weekly"
       day: "monday"
@@ -19,24 +21,24 @@ updates:
 
   # 2. TypeScript Frontend Dependencies
   - package-ecosystem: "npm"
-    directory: "/web" # Location of package.json as per architecture
+    directory: "/web" # Location of package.json
     schedule:
       interval: "weekly"
       day: "monday"
     open-pull-requests-limit: 5
     groups:
-      python-dependencies:
+      npm-dependencies:
         patterns:
-          - "*" # Groups all python updates into one PR
+          - "*" # Groups all npm updates into one PR
 
   # 3. Docker Dependencies
   - package-ecosystem: "docker"
-    directory: "/weather-app" # Location of your Dockerfile/docker-compose.yml
+    directory: "/" # Location of Dockerfile and docker-compose.yml
     schedule:
       interval: "weekly"
       day: "monday"
     open-pull-requests-limit: 5
     groups:
-      python-dependencies:
+      docker-dependencies:
         patterns:
-          - "*" # Groups all python updates into one PR
+          - "*" # Groups all docker updates into one PR


### PR DESCRIPTION
## Summary
- Fix dependabot.yml configuration errors that were causing validation failures
- Add YAML schema references for VS Code IntelliSense and validation

## Changes

### dependabot.yml
- **Fix version**: Changed from `3` to `2` (Dependabot only supports version 2)
- **Fix Python directory**: Changed from `/weather-app` to `/` (requirements.txt is in root)
- **Fix Docker directory**: Changed from `/weather-app` to `/` (Dockerfile is in root)
- **Fix group names**: 
  - npm ecosystem: `python-dependencies` → `npm-dependencies`
  - docker ecosystem: `python-dependencies` → `docker-dependencies`
- **Add schema reference**: Added YAML language server schema for VS Code validation

### codecov.yml
- **Add schema reference**: Added YAML language server schema for VS Code validation

## Testing
All changes were validated locally:
- ✅ YAML syntax validation passed
- ✅ Configuration structure validation passed
- ✅ All referenced directories and files exist
- ✅ No schema validation errors

## Why These Changes?
The exclamation marks in VS Code were indicating configuration errors:
1. Dependabot version 3 doesn't exist (only v2 is supported)
2. Wrong directory paths prevented Dependabot from finding dependency files
3. Mismatched group names were confusing (npm updates grouped as "python-dependencies")

🤖 Generated with [Claude Code](https://claude.com/claude-code)