### PR TITLE
Fix: Include web/ directory in Docker build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -41,9 +41,10 @@ README.md
 tests/
 *.log
 
-# Frontend (for backend Dockerfile)
-web/
+# Frontend build artifacts (source needed for Docker build)
 node_modules/
+web/node_modules/
+web/dist/
 
 # Local environment
 .env.local


### PR DESCRIPTION
## Summary
- Fixes Docker build failure in release workflow
- The `.dockerignore` was excluding `web/` which is needed by the multi-stage Dockerfile to build the frontend
- Keep `node_modules` and `dist` excluded as they're generated during build

## Test plan
- [ ] Release workflow should pass after merging and re-tagging

🤖 Generated with [Claude Code](https://claude.com/claude-code)